### PR TITLE
🚮 Sweep experiments older than 2019-12-06

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-story-v1": 1,
   "chunked-amp": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "chunked-amp": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -5,7 +5,6 @@
   "canary": 1,
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.1,
-  "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "chunked-amp": 1,
   "doubleclickSraExp": 0.01,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-nested-menu": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -5,7 +5,6 @@
   "canary": 1,
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.1,
-  "amp-access-iframe": 1,
   "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -11,7 +11,6 @@
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,
-  "fix-inconsistent-responsive-height-selection": 0,
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "intersect-resources": 0,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-mega-menu": 1,
   "amp-nested-menu": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -14,7 +14,6 @@
   "flexAdSlots": 0.05,
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 1,
-  "pump-early-frame": 1,
   "remove-task-timeout": 0,
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -16,7 +16,6 @@
   "ios-fixed-no-transfer": 1,
   "remove-task-timeout": 0,
   "swg-gpay-api": 1,
-  "swg-gpay-native": 1,
   "amp-ad-no-center-css": 0,
   "render-on-idle-fix": 1,
   "build-in-chunks": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "chunked-amp": 1,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -11,7 +11,6 @@
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,
-  "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-story-v1": 1,
   "chunked-amp": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -5,7 +5,6 @@
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.1,
   "amp-accordion-display-locking": 1,
-  "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "chunked-amp": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "chunked-amp": 1,
   "doubleclickSraExp": 0.01,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-nested-menu": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -11,7 +11,6 @@
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,
-  "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 0,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -14,7 +14,6 @@
   "flexAdSlots": 0.05,
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 0,
-  "pump-early-frame": 1,
   "swg-gpay-api": 1,
   "swg-gpay-native": 1,
   "amp-ad-no-center-css": 0,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -11,7 +11,6 @@
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "expand-json-targeting": 1,
-  "fix-inconsistent-responsive-height-selection": 0,
   "fixed-elements-in-lightbox": 1,
   "flexAdSlots": 0.05,
   "intersect-resources": 0,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -4,7 +4,6 @@
   "canary": 0,
   "a4aProfilingRate": 0.01,
   "adsense-ad-size-optimization": 0.1,
-  "amp-access-iframe": 1,
   "amp-accordion-display-locking": 1,
   "amp-action-macro": 1,
   "amp-ad-ff-adx-ady": 0.01,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-mega-menu": 1,
   "amp-nested-menu": 1,
   "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-playbuzz": 1,
   "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -8,7 +8,6 @@
   "amp-ad-ff-adx-ady": 0.01,
   "amp-auto-ads-adsense-holdout": 0.1,
   "ampdoc-fie": 1,
-  "amp-sidebar-swipe-to-dismiss": 1,
   "amp-story-responsive-units": 1,
   "amp-story-v1": 1,
   "chunked-amp": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -15,7 +15,6 @@
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 0,
   "swg-gpay-api": 1,
-  "swg-gpay-native": 1,
   "amp-ad-no-center-css": 0,
   "adsense-ptt-exp": 0.1,
   "doubleclick-ptt-exp": 0.1,

--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -229,7 +229,10 @@ export class AccessSource {
     }
     if (
       type == AccessType.IFRAME &&
-      !isExperimentOn(this.ampdoc.win, 'amp-access-iframe')
+      !(
+        /* isExperimentOn(this.ampdoc.win, 'amp-access-iframe') // launched: true */
+        true
+      )
     ) {
       user().error(TAG, 'Experiment "amp-access-iframe" is not enabled.');
       type = AccessType.CLIENT;

--- a/extensions/amp-access/0.1/test/test-amp-access-source.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-source.js
@@ -58,7 +58,8 @@ describes.fakeWin(
 
     afterEach(() => {
       toggleExperiment(win, 'amp-access-server', false);
-      toggleExperiment(win, 'amp-access-iframe', false);
+      /* toggleExperiment(win, 'amp-access-iframe', false) // launched: true */
+      false;
     });
 
     function expectSourceType(ampdoc, config, type, adapter) {
@@ -114,7 +115,6 @@ describes.fakeWin(
       allowConsoleError(() => {
         config['type'] = 'iframe';
         expectSourceType(ampdoc, config, 'client', AccessClientAdapter);
-        toggleExperiment(win, 'amp-access-iframe', true);
         expectSourceType(ampdoc, config, 'iframe', AccessIframeAdapter);
       });
 

--- a/extensions/amp-action-macro/0.1/amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/amp-action-macro.js
@@ -15,7 +15,6 @@
  */
 import {LayoutPriority} from '../../../src/layout';
 import {Services} from '../../../src/services';
-import {isExperimentOn} from '../../../src/experiments';
 import {userAssert} from '../../../src/log';
 
 /** @const {string} */
@@ -39,7 +38,8 @@ export class AmpActionMacro extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     userAssert(
-      isExperimentOn(this.win, 'amp-action-macro'),
+      /* isExperimentOn(this.win, 'amp-action-macro') // launched: true */
+      true,
       'Experiment is off'
     );
     const {element} = this;

--- a/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
+++ b/extensions/amp-action-macro/0.1/test/test-amp-action-macro.js
@@ -18,7 +18,6 @@ import {ActionInvocation} from '../../../../src/service/action-impl';
 import {ActionTrust} from '../../../../src/action-constants';
 import {AmpActionMacro} from '../amp-action-macro';
 import {Services} from '../../../../src/services';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin(
   'amp-action-macro',
@@ -35,8 +34,6 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-
-      toggleExperiment(win, 'amp-action-macro', true);
     });
 
     function newActionMacro() {
@@ -60,7 +57,8 @@ describes.realWin(
 
     it('should not build if experiment is off', () => {
       return allowConsoleError(() => {
-        toggleExperiment(env.win, 'amp-action-macro', false);
+        /* toggleExperiment(env.win, 'amp-action-macro', false) // launched: true */
+        false;
         return newActionMacro().catch((err) => {
           expect(err.message).to.include('Experiment is off');
         });
@@ -75,8 +73,6 @@ describes.realWin(
       let unreferrableMacro;
       let unreferrableMacroElement;
       beforeEach(() => {
-        toggleExperiment(win, 'amp-action-macro', true);
-
         // This macro is referrable and can be invoked by the macro element(s)
         // defined after it.
         referrableMacroElement = doc.createElement('amp-action-macro');

--- a/extensions/amp-playbuzz/0.1/amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/amp-playbuzz.js
@@ -49,7 +49,6 @@ import {
 } from '../../../src/url';
 import {dev, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {isExperimentOn} from '../../../src/experiments';
 import {logo, showMoreArrow} from './images';
 import {
   observeWithSharedInOb,
@@ -109,7 +108,8 @@ class AmpPlaybuzz extends AMP.BaseElement {
     // EXPERIMENT
     // AMP.toggleExperiment(EXPERIMENT, true); //for dev
     userAssert(
-      isExperimentOn(this.win, 'amp-playbuzz'),
+      /* isExperimentOn(this.win, 'amp-playbuzz') // launched: true */
+      true,
       'Enable amp-playbuzz experiment'
     );
 

--- a/extensions/amp-playbuzz/0.1/test/test-amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/test/test-amp-playbuzz.js
@@ -15,7 +15,6 @@
  */
 
 import '../amp-playbuzz';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin(
   'amp-playbuzz',
@@ -30,7 +29,6 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      toggleExperiment(win, 'amp-playbuzz', true);
     });
 
     function createOptionalParams(

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -34,7 +34,6 @@ import {descendsFromStory} from '../../../src/utils/story';
 import {dev, devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {handleAutoscroll} from './autoscroll';
-import {isExperimentOn} from '../../../src/experiments';
 import {removeFragment} from '../../../src/url';
 import {setModalAsClosed, setModalAsOpen} from '../../../src/modal';
 import {setStyles, toggle} from '../../../src/style';
@@ -573,7 +572,12 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   setupGestures_(element) {
-    if (!isExperimentOn(this.win, 'amp-sidebar-swipe-to-dismiss')) {
+    if (
+      !(
+        /* isExperimentOn(this.win, 'amp-sidebar-swipe-to-dismiss') // launched: true */
+        true
+      )
+    ) {
       return;
     }
     // stop propagation of swipe event inside amp-viewer

--- a/extensions/amp-sidebar/0.2/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/amp-sidebar.js
@@ -574,7 +574,12 @@ export class AmpSidebar extends AMP.BaseElement {
    * @private
    */
   setupGestures_(element) {
-    if (!isExperimentOn(this.win, 'amp-sidebar-swipe-to-dismiss')) {
+    if (
+      !(
+        /* isExperimentOn(this.win, 'amp-sidebar-swipe-to-dismiss') // launched: true */
+        true
+      )
+    ) {
       return;
     }
     // stop propagation of swipe event inside amp-viewer

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -586,7 +586,12 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   rewriteStyles_(styleEl) {
-    if (!isExperimentOn(this.win, 'amp-story-responsive-units')) {
+    if (
+      !(
+        /* isExperimentOn(this.win, 'amp-story-responsive-units') // launched: true */
+        true
+      )
+    ) {
       return;
     }
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -1656,12 +1656,11 @@ describes.realWin(
       });
 
       describe('amp-story rewriteStyles', () => {
-        beforeEach(() => {
-          toggleExperiment(win, 'amp-story-responsive-units', true);
-        });
+        beforeEach(() => {});
 
         afterEach(() => {
-          toggleExperiment(win, 'amp-story-responsive-units', false);
+          /* toggleExperiment(win, 'amp-story-responsive-units', false) // launched: true */
+          false;
         });
 
         it('should rewrite vw styles', async () => {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -479,7 +479,7 @@ function maybeLoadCorrectVersion(win, fnOrStruct) {
  *     pumped.
  */
 function maybePumpEarlyFrame(win, cb) {
-  if (!isExperimentOn(win, 'pump-early-frame')) {
+  if (!(/* isExperimentOn(win, 'pump-early-frame') // launched: true */ true)) {
     cb();
     return;
   }

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -33,7 +33,6 @@ import {installPlatformService} from '../../src/service/platform-impl';
 import {installTimerService} from '../../src/service/timer-impl';
 import {setShadowDomSupportedVersionForTesting} from '../../src/web-components';
 import {toArray} from '../../src/types';
-import {toggleExperiment} from '../../src/experiments';
 import {vsyncForTesting} from '../../src/service/vsync-impl';
 
 describes.fakeWin(
@@ -202,7 +201,6 @@ describes.fakeWin(
     );
 
     it('should not maybePumpEarlyFrame when body not yet present', () => {
-      toggleExperiment(win, 'pump-early-frame', true);
       // Make document.body be null on first invocation to simulate
       // JS executing before the rest of the doc has been parsed.
       const {body} = win.document;
@@ -223,14 +221,12 @@ describes.fakeWin(
       'should not maybePumpEarlyFrame ' +
         'when a renderDelayingExtension is present',
       () => {
-        toggleExperiment(win, 'pump-early-frame', true);
         win.document.body.appendChild(document.createElement('amp-experiment'));
         extensionRegistrationTest();
       }
     );
 
     it('should maybePumpEarlyFrame and delay extension execution', () => {
-      toggleExperiment(win, 'pump-early-frame', true);
       let progress = '';
       const queueExtensions = win.AMP;
       const highPriority = regularExtension((amp) => {

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -90,13 +90,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/22220',
   },
   {
-    id: 'pump-early-frame',
-    name:
-      'If applicable, let the browser paint the current frame before ' +
-      'executing the callback.',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8237',
-  },
-  {
     id: 'web-worker',
     name: 'Web worker for background processing',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/7156',

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -133,12 +133,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/14357',
   },
   {
-    id: 'amp-story-responsive-units',
-    name: 'Scale pages in amp-story by rewriting responsive units',
-    spec: 'https://github.com/ampproject/amphtml/issues/15955',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/15960',
-  },
-  {
     id: 'amp-next-page',
     name: 'Document level next page recommendations and infinite scroll',
     spec: 'https://github.com/ampproject/amphtml/issues/12945',

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -90,11 +90,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/22220',
   },
   {
-    id: 'chunked-amp',
-    name: "Split AMP's loading phase into chunks",
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5535',
-  },
-  {
     id: 'pump-early-frame',
     name:
       'If applicable, let the browser paint the current frame before ' +

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -90,12 +90,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/pull/6351',
   },
   {
-    id: 'amp-action-macro',
-    name: 'AMP extension for defining action macros',
-    spec: 'https://github.com/ampproject/amphtml/issues/19494',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/pull/19495',
-  },
-  {
     id: 'ios-fixed-no-transfer',
     name: 'Remove fixed transfer from iOS 12.2 and up',
     spec: 'https://github.com/ampproject/amphtml/issues/22220',

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -84,12 +84,6 @@ export const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/7743',
   },
   {
-    id: 'amp-playbuzz',
-    name: 'AMP extension for playbuzz items (launched)',
-    spec: 'https://github.com/ampproject/amphtml/issues/6106',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/pull/6351',
-  },
-  {
     id: 'ios-fixed-no-transfer',
     name: 'Remove fixed transfer from iOS 12.2 and up',
     spec: 'https://github.com/ampproject/amphtml/issues/22220',

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -177,12 +177,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/24165',
   },
   {
-    id: 'fix-inconsistent-responsive-height-selection',
-    name: 'Fix inconsistent responsive height selection.',
-    spec: 'https://github.com/ampproject/amphtml/issues/24166',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/24167',
-  },
-  {
     id: 'intersect-resources',
     name: 'Use IntersectionObserver for resource scheduling.',
     spec: 'https://github.com/ampproject/amphtml/issues/25428',

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -31,12 +31,6 @@ export const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/4005',
   },
   {
-    id: 'amp-access-iframe',
-    name: 'AMP Access iframe prototype (launched)',
-    spec: 'https://github.com/ampproject/amphtml/issues/13287',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/13287',
-  },
-  {
     id: 'amp-access-server',
     name: 'AMP Access server side prototype',
     spec: '',


### PR DESCRIPTION
Sweep experiments last flipped globally up to 2019-12-06:

- (2018-07-23, 4eccc142b) `amp-access-iframe`: 1
- (2019-10-01, 0ab715ef1) `amp-action-macro`: 1
- (2019-11-08, fa7417d95) `amp-mega-menu`: 1
- (2019-11-13, ee0ad23d7) `amp-nested-menu`: 1
- (2017-02-07, eeebd9303) `amp-playbuzz`: 1
- (2019-10-21, 24ceaf501) `amp-sidebar-swipe-to-dismiss`: 1
- (2018-11-05, d26327a3c) `amp-story-responsive-units`: 1
- (2018-07-11, 366b9d53e) `amp-story-v1`: 1
- (2018-07-11, 366b9d53e) `chunked-amp`: 1
- (2019-10-28, 4ca140956) `fix-inconsistent-responsive-height-selection`: 0
- (2019-02-26, 27ccef3b0) `fixed-elements-in-lightbox`: 1
- (2017-05-16, ca2005971) `pump-early-frame`: 1
- (2019-11-12, 31f7e2267) `swg-gpay-native`: 1

---

### ⚠️ Javascript source files require intervention

The following may contain errors and/or require intervention to remove superfluous conditionals:

- `extensions/amp-access/0.1/amp-access-source.js`
- `extensions/amp-access/0.1/test/test-amp-access-source.js`
- `extensions/amp-action-macro/0.1/amp-action-macro.js`
- `extensions/amp-action-macro/0.1/test/test-amp-action-macro.js`
- `extensions/amp-playbuzz/0.1/amp-playbuzz.js`
- `extensions/amp-playbuzz/0.1/test/test-amp-playbuzz.js`
- `extensions/amp-sidebar/0.1/amp-sidebar.js`
- `extensions/amp-sidebar/0.2/amp-sidebar.js`
- `extensions/amp-story/1.0/amp-story.js`
- `extensions/amp-story/1.0/test/test-amp-story.js`
- `src/runtime.js`
- `test/unit/test-runtime.js`

Refer to the removal guide for [suggestions on handling these modified Javascript files.](https://github.com/ampproject/amphtml/build-system/tasks/sweep-experiments#followup)

---

### ⚠️ HTML files may still contain references

The following HTML files contain references to experiment names which may be stale and should be manually removed:

- `examples/playbuzz.amp.html`
- `examples/responsive-menu.amp.html`
- `examples/visual-tests/amp-mega-menu/amp-mega-menu.amp.html`
- `examples/visual-tests/amp-mega-menu/amp-mega-menu-with-list.amp.html`
- `examples/amp-action-macro.html`
- `test/manual/amp-mega-menu/amp-mega-menu.amp.html`
- `test/manual/amp-mega-menu/amp-mega-menu-with-list.amp.html`

Refer to the removal guide for [suggestions on handling these HTML files.](https://github.com/ampproject/amphtml/build-system/tasks/sweep-experiments#followup:html)
